### PR TITLE
Add test to check verify when wrong public key is used

### DIFF
--- a/data_structures/keys.test.py
+++ b/data_structures/keys.test.py
@@ -30,6 +30,27 @@ class Test(unittest.TestCase):
         # Return if validity is true
         self.assertTrue(verifying_key.verify(signature, some_random_hash_string))
 
+    def test_verify_wrong_public_key(self):
+        # Use generated private key to generate a public key
+        key = generate_private_key()
+        public_key = generate_public_key(key)
+        # Generate second public/private key
+        key_2 = generate_private_key()
+        public_key_2 = generate_public_key(key_2)
+        # Checking the right data type
+        self.assertIsInstance(public_key, bytes)
+        self.assertIsInstance(public_key_2, bytes)
+        # Generate random string so we can sign it using private key
+        signing_key = ecdsa.SigningKey.from_string(key, curve = ecdsa.SECP256k1)
+        some_random_hash_string = hash_SHA("some_random_string".encode())
+        # Creating a signature that can only be created by the private key holder
+        signature = signing_key.sign(some_random_hash_string)
+        # Using the second public key to verifying the signature
+        verifying_key = ecdsa.VerifyingKey.from_string(public_key_2, ecdsa.SECP256k1)
+        # Return if verify raises BadSiginatureError
+        with self.assertRaises(ecdsa.BadSignatureError):
+            verifying_key.verify(signature, some_random_hash_string)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Verify doesn't return `False` when the wrong public key is used it raises `BadSignatureError` so that is what I wrote the test to check